### PR TITLE
feat: expose `envFile` to overide env path, and build `environment` option for run command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metacraft/cli",
-  "version": "0.0.81",
+  "version": "0.0.84",
   "description": "lightning fast development/boilerplate tool for javascript/node.js",
   "author": "Walless Tribe",
   "bin": {

--- a/src/commands/bundle/index.ts
+++ b/src/commands/bundle/index.ts
@@ -5,12 +5,12 @@ import {
 	guessEnvironmentEntry,
 	parseConfigs,
 } from 'utils/cli';
-import { MetacraftOptions } from 'utils/configs';
+import { RootOptions } from 'utils/configs';
 import { CommandModule, Options } from 'yargs';
 
 import { bundleNodeBuild, bundleWebBuild } from './bundler';
 
-const module: CommandModule<object, MetacraftOptions> = {
+const module: CommandModule<object, RootOptions> = {
 	command: 'bundle',
 	aliases: ['build', 'compile'],
 	describe: 'Build production bundle',

--- a/src/commands/bundle/index.ts
+++ b/src/commands/bundle/index.ts
@@ -5,11 +5,12 @@ import {
 	guessEnvironmentEntry,
 	parseConfigs,
 } from 'utils/cli';
+import { MetacraftOptions } from 'utils/configs';
 import { CommandModule, Options } from 'yargs';
 
 import { bundleNodeBuild, bundleWebBuild } from './bundler';
 
-const module: CommandModule = {
+const module: CommandModule<object, MetacraftOptions> = {
 	command: 'bundle',
 	aliases: ['build', 'compile'],
 	describe: 'Build production bundle',
@@ -21,8 +22,13 @@ const module: CommandModule = {
 	handler: async (args) => {
 		global.setEnv('ENV', args.e);
 		global.setEnv('NODE_ENV', args.e);
-		const envEntry = await guessEnvironmentEntry(true);
-		loadEnvironmentVariables({ path: envEntry });
+
+		if (args.env) {
+			loadEnvironmentVariables({ path: args.envFile });
+		} else {
+			const envEntry = await guessEnvironmentEntry(true);
+			loadEnvironmentVariables({ path: envEntry });
+		}
 
 		const internal = await extractInternals();
 		const parsedConfigs = parseConfigs(internal.configs, args);

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -9,16 +9,21 @@ import {
 	guessEnvironmentEntry,
 	parseConfigs,
 } from 'utils/cli';
+import { MetacraftOptions } from 'utils/configs';
 import { type CommandModule } from 'yargs';
 
-const module: CommandModule = {
+const module: CommandModule<object, MetacraftOptions> = {
 	command: '$0',
 	aliases: ['dev'],
 	describe: 'Launch development server(s)',
 	builder: (yargs) => yargs.default('p', 3000),
 	handler: async (args) => {
-		const envEntry = await guessEnvironmentEntry(false);
-		loadEnvironmentVariables({ path: envEntry });
+		if (args.env) {
+			loadEnvironmentVariables({ path: args.envFile });
+		} else {
+			const envEntry = await guessEnvironmentEntry(false);
+			loadEnvironmentVariables({ path: envEntry });
+		}
 
 		const internal = await extractInternals();
 		const { logger } = internal.modules;

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -10,14 +10,19 @@ import {
 	parseConfigs,
 } from 'utils/cli';
 import { MetacraftOptions } from 'utils/configs';
-import { type CommandModule } from 'yargs';
+import { type CommandModule, Options } from 'yargs';
 
-const module: CommandModule<object, MetacraftOptions> = {
+type RunOptions = MetacraftOptions & { e?: string };
+
+const module: CommandModule<object, RunOptions> = {
 	command: '$0',
 	aliases: ['dev'],
 	describe: 'Launch development server(s)',
-	builder: (yargs) => yargs.default('p', 3000),
+	builder: (yargs) => yargs.default('p', 3000).options(runOptions),
 	handler: async (args) => {
+		global.setEnv('ENV', args.e);
+		global.setEnv('NODE_ENV', args.e);
+
 		if (args.env) {
 			loadEnvironmentVariables({ path: args.envFile });
 		} else {
@@ -49,3 +54,12 @@ const module: CommandModule<object, MetacraftOptions> = {
 };
 
 export default module;
+
+const runOptions = {
+	environment: {
+		alias: 'e',
+		type: 'string',
+		default: 'development',
+		describe: 'Build environment',
+	} as Options,
+};

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -9,10 +9,10 @@ import {
 	guessEnvironmentEntry,
 	parseConfigs,
 } from 'utils/cli';
-import { MetacraftOptions } from 'utils/configs';
+import { RootOptions } from 'utils/configs';
 import { type CommandModule, Options } from 'yargs';
 
-type RunOptions = MetacraftOptions & { e?: string };
+type RunOptions = RootOptions & { e?: string };
 
 const module: CommandModule<object, RunOptions> = {
 	command: '$0',

--- a/src/utils/configs.ts
+++ b/src/utils/configs.ts
@@ -31,7 +31,7 @@ export const options: Record<string, Options> = {
 	},
 };
 
-export type MetacraftOptions = {
+export type RootOptions = {
 	port?: number;
 	host?: string;
 	devOnly?: boolean;

--- a/src/utils/configs.ts
+++ b/src/utils/configs.ts
@@ -25,7 +25,7 @@ export const options: Record<string, Options> = {
 	},
 	ef: {
 		description:
-			"Force load env file, by default we use '.env.development' for run, and '.env.production' for build",
+			"Force load env file, by default we use '.env.development' for run command, and '.env.production' for build command",
 		alias: 'envFile',
 		type: 'string',
 	},

--- a/src/utils/configs.ts
+++ b/src/utils/configs.ts
@@ -1,4 +1,4 @@
-import type { Options } from 'yargs';
+import { type Options } from 'yargs';
 
 export const options: Record<string, Options> = {
 	p: {
@@ -23,4 +23,17 @@ export const options: Record<string, Options> = {
 		alias: 'devOnly',
 		type: 'boolean',
 	},
+	ef: {
+		description:
+			"Force load env file, by default we use '.env.development' for run, and '.env.production' for build",
+		alias: 'envFile',
+		type: 'string',
+	},
+};
+
+export type MetacraftOptions = {
+	port?: number;
+	host?: string;
+	devOnly?: boolean;
+	envFile?: string;
 };


### PR DESCRIPTION
To use `run` command with production mode, we can use `metacraft --envFile .env.production -e production`